### PR TITLE
Fix deactive() and deactivation_request_to_file()

### DIFF
--- a/turboactivate/__init__.py
+++ b/turboactivate/__init__.py
@@ -118,9 +118,9 @@ class TurboActivate(object):
         """
 
         if erase_p_key is True:
-            args = c_char("1")
+            args = 1
         else:
-            args = c_char("0")
+            args = 0
 
         try:
             self._lib.TA_Deactivate(self._handle, args)
@@ -140,9 +140,9 @@ class TurboActivate(object):
         args = [wstr(filename)]
 
         if erase_p_key is True:
-            args.append(c_char("1"))
+            args.append(1)
         else:
-            args.append(c_char("0"))
+            args.append(0)
 
         try:
             self._lib.TA_DeactivationRequestToFile(self._handle, *args)


### PR DESCRIPTION
Do not need to turn the erase_p_key flag into a c_char()

I made a mistake and it does not seem to work if you turn the Python int into a c_char before passing the argument. Apologies, and as we do not use the online activation method I have not tested it but expect it works too now.

