### PR TITLE
Fix ctype error

### DIFF
--- a/turboactivate/c_wrapper.py
+++ b/turboactivate/c_wrapper.py
@@ -41,7 +41,16 @@ from ctypes import (
 
 wbuf = create_unicode_buffer if sys.platform == "win32" else create_string_buffer
 
-wstr = c_wchar_p if sys.platform == "win32" else c_char_p
+wstr_type = c_wchar_p if sys.platform == "win32" else c_char_p
+
+
+class wstr(wstr_type):
+    def __init__(self, string):
+        if (sys.version_info > (3, 0)):
+            super(wstr, self).__init__(string.encode('utf-8'))
+        else:
+            super(wstr, self).__init__(string)
+
 
 # Wrapper
 


### PR DESCRIPTION
https://docs.python.org/3/library/ctypes.html
https://docs.python.org/2/library/ctypes.html

If you compare the definitions for c_char_p from above you will see that an issue occurs because in Python 3 strings are not encoded by default and so you get a TypeError when running Python 3:
```python
TypeError: bytes or integer address expected instead of str instance
```

This pull request fixes this by creating a custom class to perform the encoding if it is necessary. It would also probably work to remove the `if (sys.version_info > (3, 0))` and just always perform the encoding.

Comments or feedback welcome.