### PR TITLE
In windows and python 3 the api breaks due to mismatch of c_wchar_p and bytes class returned from string.encode('utf-8').

### DIFF
--- a/turboactivate/c_wrapper.py
+++ b/turboactivate/c_wrapper.py
@@ -39,15 +39,15 @@ from ctypes import (
 
 # Utilities
 
-wbuf = create_unicode_buffer if sys.platform == "win32" else create_string_buffer
+wbuf = create_unicode_buffer
 
-wstr_type = c_wchar_p if sys.platform == "win32" else c_char_p
+wstr_type = c_wchar_p 
 
 
 class wstr(wstr_type):
     def __init__(self, string):
         if (sys.version_info > (3, 0)):
-            super(wstr, self).__init__(string.encode('utf-8'))
+            super(wstr, self).__init__(string))
         else:
             super(wstr, self).__init__(string)
 

--- a/turboactivate/c_wrapper.py
+++ b/turboactivate/c_wrapper.py
@@ -39,15 +39,15 @@ from ctypes import (
 
 # Utilities
 
-wbuf = create_unicode_buffer
+wbuf = create_unicode_buffer if sys.platform == "win32" else create_string_buffer
 
-wstr_type = c_wchar_p 
+wstr_type = c_wchar_p if sys.platform == "win32" else c_char_p
 
 
 class wstr(wstr_type):
     def __init__(self, string):
         if (sys.version_info > (3, 0)):
-            super(wstr, self).__init__(string))
+            super(wstr, self).__init__(string.encode('utf-8'))
         else:
             super(wstr, self).__init__(string)
 

--- a/turboactivate/c_wrapper.py
+++ b/turboactivate/c_wrapper.py
@@ -39,15 +39,20 @@ from ctypes import (
 
 # Utilities
 
-wbuf = create_unicode_buffer if sys.platform == "win32" else create_string_buffer
+# python 2.7 string.encode('utf-8') returns an str class
+# python 3.6 string.encode('utf-8') returns a bytes class
 
-wstr_type = c_wchar_p if sys.platform == "win32" else c_char_p
+is_win = if sys.platform == "win32" 
+
+wbuf = create_unicode_buffer if is_win else create_string_buffer
+
+wstr_type = c_wchar_p if is_win else c_char_p
 
 
 class wstr(wstr_type):
     def __init__(self, string):
         if (sys.version_info > (3, 0)):
-            super(wstr, self).__init__(string.encode('utf-8'))
+            super(wstr, self).__init__(string.encode('utf-8') if not is_win else string)
         else:
             super(wstr, self).__init__(string)
 


### PR DESCRIPTION
in windows and python 3, the api breaks  due to mismatch of c_wchar_p and bytes class returned from string.encode('utf-8').

The fix checks if it's not windows, and in that case uses string.encode('utg-8'), otherwise will use regular string, as regular strings in python 3 are Unicode.